### PR TITLE
Switched to 24 hour time formats

### DIFF
--- a/src/includes/notices/schedule-overview.liquid
+++ b/src/includes/notices/schedule-overview.liquid
@@ -2,7 +2,7 @@
 <ul class="list-unstyled list-schedule-overview text-muted" id="#schedule-overview-{{ notice.id }}">
 	<li class="schedule-datetime">
 		<!-- Format the begins-date datetime as something more friendly. -->
-		{% assign begins_at = notice.begins_at | date: '%a, %-d %b %Y %-l:%M %p %Z' %}
+		{% assign begins_at = notice.begins_at | date: '%a, %-d %b %Y %H:%M %Z' %}
 		<!-- Display the begins-at datetime for the notice. -->
 		<i class="fa fa-fw fa-calendar"></i> {{ 'status-page.body.schedule.for' | t: begins_at: begins_at }}
 	</li>

--- a/src/maintenance-page.liquid
+++ b/src/maintenance-page.liquid
@@ -53,7 +53,7 @@
 							<!-- The SP does have noticed, display an ongoing statement and link. -->
 							<h2 class="h4 notice-subject">{{ notice.subject }}</h2>
 								<p class="notice-synopsis">{{ notice.synopsis | simple_format }}</p>
-								<p class="notice-schedule"><small><strong>{{ 'maintenance-page.body.states.with-maintenance.began_at' | t }}:</strong> {{ notice.began_at | date: '%A, %-d %b %Y %-l:%M %p %Z' }} <br /> <strong>{{ 'maintenance-page.body.states.with-maintenance.duration' | t }}:</strong> <time class="duration" datetime="{{ notice.expected_duration }}s">{{ notice.expected_duration | distance_of_time_in_words }}</time></small></p>
+								<p class="notice-schedule"><small><strong>{{ 'maintenance-page.body.states.with-maintenance.began_at' | t }}:</strong> {{ notice.began_at | date: '%A, %-d %b %Y %H:%M %Z' }} <br /> <strong>{{ 'maintenance-page.body.states.with-maintenance.duration' | t }}:</strong> <time class="duration" datetime="{{ notice.expected_duration }}s">{{ notice.expected_duration | distance_of_time_in_words }}</time></small></p>
 						</div>
 
 						<div class="spacer spacer-md"></div>


### PR DESCRIPTION
Many languages we're adding don't use AM/PM and a 12 hour time format, so it becomes confusing for the audience.

This switches us over to 24 hour formats, which are much more universal.