### PR TITLE
Began and Ended Timestamps

### DIFF
--- a/src/includes/notices/timeliness.liquid
+++ b/src/includes/notices/timeliness.liquid
@@ -1,5 +1,7 @@
 <!-- Determine a friendly duration. -->
 {% assign duration = notice.duration | distance_of_time_in_words %}
+{% assign began_at = notice.began_at | date: '%e %B %k:%M' %}
+{% assign ended_at = notice.ended_at | date: '%e %B %k:%M' %}
 
 <!-- Generate a moment.js time tag for the begins_at. -->
 {% capture begins_in %}
@@ -14,4 +16,4 @@
 {% endcapture %}
 
 <!-- Display a simple subheading. -->
-<small class="notice-type">{{ 'status-page.' | append: placement | append: '.timeliness.' | append: notice.type | append: '.' | append: notice.state | t: begins_in: begins_in, ends_in: ends_in, duration: duration, began_at: notice.began_at, ended_at: notice.ended_at }}</small>
+<small class="notice-type">{{ 'status-page.' | append: placement | append: '.timeliness.' | append: notice.type | append: '.' | append: notice.state | t: begins_in: begins_in, ends_in: ends_in, duration: duration, began_at: began_at, ended_at: ended_at }}</small>

--- a/src/includes/notices/timeliness.liquid
+++ b/src/includes/notices/timeliness.liquid
@@ -14,4 +14,4 @@
 {% endcapture %}
 
 <!-- Display a simple subheading. -->
-<small class="notice-type">{{ 'status-page.' | append: placement | append: '.timeliness.' | append: notice.type | append: '.' | append: notice.state | t: begins_in: begins_in, ends_in: ends_in, duration: duration }}</small>
+<small class="notice-type">{{ 'status-page.' | append: placement | append: '.timeliness.' | append: notice.type | append: '.' | append: notice.state | t: begins_in: begins_in, ends_in: ends_in, duration: duration, began_at: notice.began_at, ended_at: notice.ended_at }}</small>

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -61,7 +61,7 @@
 				},
 				"unplanned": {
 					"closed": "Denne hændelse varede %{duration}.",
-					"resolved": "Denne hændelse varede %{duration}.",
+					"resolved": "Begyndte: %{began_at} - Færdig: %{ended_at} - Varighed: %{duration}.",
 					"false_alarm": "Denne hændelse blev betragtet som en falsk alarm efter %{duration}"
 				}
 			},

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -61,7 +61,7 @@
                 },
                 "unplanned": {
                     "closed": "Dieses Ereignis dauerte %{duration}.",
-                    "resolved": "Dieses Ereignis dauerte %{duration}.",
+                    "resolved": "Beginn: %{began_at} - Ende: %{ended_at} - Dauer: %{duration}.",
                     "false_alarm": "Dieser Vorfall wurde als falscher Alarm nach %{duration} geschloßen."
                 }
             },

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -61,7 +61,7 @@
 				},
 				"unplanned": {
 					"closed": "Το περιστατικό διήρκεσε %{duration}.",
-					"resolved": "Το περιστατικό διήρκεσε %{duration}.",
+                    "resolved": "Ξεκίνησε: %{began_at} - Τέλος: %{ended_at} - Διάρκεια: %{duration}.",
 					"false_alarm": "Αυτό το περιστατικό θεωρήθηκε ψευδές συναγερμό μετά %{duration}"
 				}
 			},

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -61,7 +61,7 @@
 				},
 				"unplanned": {
 					"closed": "This incident lasted %{duration}.",
-					"resolved": "This incident lasted %{duration}.",
+					"resolved": "Began: %{began_at} - Ended: %{ended_at} - Duration: %{duration}.",
 					"false_alarm": "This incident was deemed a false alarm after %{duration}"
 				}
 			},

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -61,7 +61,7 @@
 				},
 				"unplanned": {
 					"closed": "Este incidente duró %{duration}.",
-					"resolved": "Este incidente duró %{duration}.",
+                    "resolved": "Comenzó: %{began_at} - Terminó: %{ended_at} - Duración: %{duration}.",
 					"false_alarm": "Este incidente fue considerado una falsa alarma %{duration}"
 				}
 			},

--- a/src/locales/et.json
+++ b/src/locales/et.json
@@ -61,7 +61,7 @@
 				},
 				"unplanned": {
 					"closed": "See intsident kestis %{duration}.",
-					"resolved": "See intsident kestis %{duration}.",
+                    "resolved": "Algus: %{began_at} - lõppenud: %{ended_at} - kestus: %{duration}.",
 					"false_alarm": "See intsident oli vale alarm %{duration}"
 				}
 			},

--- a/src/locales/fi..json
+++ b/src/locales/fi..json
@@ -61,7 +61,7 @@
 				},
 				"unplanned": {
 					"closed": "Tapahtuman kesto oli %{duration}.",
-					"resolved": "Tapahtuman kesto oli %{duration}.",
+                    "resolved": "Aloitettu: %{began_at} - päättynyt: %{ended_at} - Kesto: %{duration}.",
 					"false_alarm": "Tämä tapahtuma katsottiin olevan väärä hälytys %{duration} jälkeen"
 				}
 			},

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -61,7 +61,7 @@
 				},
 				"unplanned": {
 					"closed": "Cet incident a duré %{duration}.",
-					"resolved": "Cet incident a duré %{duration}.",
+                    "resolved": "Début: %{began_at} - Fin: %{ended_at} - Durée: %{duration}.",
 					"false_alarm": "Cet incident a été considéré comme une fausse alarme après %{duration}"
 				}
 			},

--- a/src/locales/nb.json
+++ b/src/locales/nb.json
@@ -61,7 +61,7 @@
 				},
 				"unplanned": {
 					"closed": "Denne hendelsen varte %{duration}.",
-					"resolved": "Denne hendelsen varte %{duration}.",
+                    "resolved": "Begynte: %{began_at} - Avsluttet: %{ended_at} - Varighet: %{duration}.",
 					"false_alarm": "Denne hendelsen ble ansett som en falsk alarm etter %{duration}"
 				}
 			},

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -61,7 +61,7 @@
 				},
 				"unplanned": {
 					"closed": "Dit incident duurde %{duration}.",
-					"resolved": "Dit incident duurde %{duration}.",
+                    "resolved": "Begon: %{began_at} - Beëindigd: %{ended_at} - Duur: %{duration}.",
 					"false_alarm": "Dit incident werd gemarkeerd als vals alarm na %{duration}"
 				}
 			},

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -61,7 +61,7 @@
                 },
                 "unplanned": {
                     "closed": "Zdarzenie trwało %{duration}.",
-                    "resolved": "Zdarzenie trwało %{duration}.",
+                    "resolved": "Rozpoczęty: %{began_at} - Zakończony: %{ended_at} - Czas trwania: %{duration}.",
                     "false_alarm": "Zdarzenie zostało uznane za fałszywy alarm po %{duration}"
                 }
             },

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -61,7 +61,7 @@
                 },
                 "unplanned": {
                     "closed": "Este incidente teve duração de %{duration}.",
-                    "resolved": "Este incidente teve duração de %{duration}.",
+                    "resolved": "Início: %{began_at} - Finalizado: %{ended_at} - Duração: %{duration}.",
                     "false_alarm": "Este incidente foi considerado um alarme falso após %{duration}"
                 }
             },

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -61,7 +61,7 @@
 				},
 				"unplanned": {
 					"closed": "Этот инцидент длился %{duration}.",
-					"resolved": "Этот инцидент длился %{duration}.",
+                    "resolved": "Начало: %{began_at} - Закончено: %{ended_at} - Продолжительность: %{duration}.",
 					"false_alarm": "Этот инцидент был признан ложной тревогой через %{duration}"
 				}
 			},

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -61,7 +61,7 @@
 				},
 				"unplanned": {
 					"closed": "Denna incident varade %{duration}.",
-					"resolved": "Denna incident varade %{duration}.",
+                    "resolved": "Började: %{began_at} - Avslutat: %{ended_at} - Varaktighet: %{duration}.",
 					"false_alarm": "Denna händelse ansågs vara ett falskt larm efter %{duration}"
 				}
 			},

--- a/src/stylesheets/partials/timelines.less
+++ b/src/stylesheets/partials/timelines.less
@@ -117,7 +117,7 @@ dl.timeline {
 		/* Subheading styles. */
 		.notice-type { 
 			display: block;
-			opacity: 0.6;
+			opacity: 0.8;
 			font-size: 85%;
 			line-height: 1.41;
 			margin-bottom: (@line-height-computed / 2);


### PR DESCRIPTION
Contribution to #105  - Added the began/ended timestamps to the timeliness section alongside the duration. This is because the ability to set and edit the timestamps was recently added to the publishing UI, and may differ from the actual timestamp that the notice was created, or updated.

Includes Google Translate versions for all languages other than English, which may need some tweaks once we get customer feedback.