### PR TITLE
Remove overview heading

### DIFF
--- a/src/includes/notices/update-content.liquid
+++ b/src/includes/notices/update-content.liquid
@@ -10,10 +10,6 @@
 
 <!-- Check if this is maintenance and synopsis. -->
 {% if notice.type == 'planned' and update.id == synopsis.id %}
-    <!-- This is a planned notice synopsis, so we want heading + schedule -->
-    <!-- Include the synopsis header. -->
-    <h5 class="update-heading">{{ 'status-page.body.schedule.synopsis' | t }}</h5>
-
     <!-- Just a standard update, output the content. -->
     {{ update.content | simple_format }}
 

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Oversigt",
                 "for": "Planlagt til %{begins_at}",
                 "expected_duration": "Forventes at tage %{expected_duration}"
             },

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Übersicht",
                 "for": "Geplant für %{begins_at}",
                 "expected_duration": "Voraussichtliche Dauer: %{expected_duration}"
             },

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Συνολική εικόνα",
                 "for": "Προγραμματισμενο για %{begins_at}",
                 "expected_duration": "Αναμένεται να λάβει %{expected_duration}"
             },

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Overview",
                 "for": "Scheduled for %{begins_at}",
                 "expected_duration": "Expected to take %{expected_duration}"
             },

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Visión de conjunto",
                 "for": "Programado para %{begins_at}",
                 "expected_duration": "Se espera que tome %{expected_duration}"
             },

--- a/src/locales/et.json
+++ b/src/locales/et.json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Ülevaade",
                 "for": "Planeeritud: %{begins_at}",
                 "expected_duration": "Arvatud kestus %{expected_duration}"
             },

--- a/src/locales/fi..json
+++ b/src/locales/fi..json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Kuvaus",
                 "for": "Ajoitettu %{begins_at}",
                 "expected_duration": "Odotettu kesto %{expected_duration}"
             },

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Vue d'ensemble",
                 "for": "Planifié pour %{begins_at}",
                 "expected_duration": "Prévu pour prendre %{expected_duration}"
             },

--- a/src/locales/nb.json
+++ b/src/locales/nb.json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Oversikt",
                 "for": "Planlagt %{begins_at}",
                 "expected_duration": "Forventet å ta %{expected_duration}"
             },

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Overzicht",
                 "for": "Gepland voor %{begins_at}",
                 "expected_duration": "Verwachte duur %{expected_duration}"
             },

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Przegląd",
                 "for": "Start %{begins_at}",
                 "expected_duration": "Szacowany czas pracy %{expected_duration}"
             },

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Panorama geral",
                 "for": "Programado para %{begins_at}",
                 "expected_duration": "Esperado durar %{expected_duration}"
             },

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Обзор",
                 "for": "Запланировано на %{begins_at} ",
                 "expected_duration": "Должно занять %{expected_duration}"
             },

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -66,7 +66,6 @@
                 }
             },
             "schedule": {
-                "synopsis": "Översikt",
                 "for": "Schemalagt för %{begins_at}",
                 "expected_duration": "Förväntas ta %{expected_duration}"
             },

--- a/src/stylesheets/partials/timelines.less
+++ b/src/stylesheets/partials/timelines.less
@@ -203,9 +203,6 @@ dl.timeline {
                     > dd {
                         margin-bottom: @timeline-vertical-spacing;
 
-                        // Header for planned notices.
-                        .update-heading { line-height: @line-height-computed; }
-
                         // Graphical timeline on larger scale devices.
                         @media (min-width: @grid-float-breakpoint) {
                             /* Horizontal alignment of dates/times. */


### PR DESCRIPTION
Contribution to #114 - Remove the "overview" heading from planned notices, as this was creating some needlessly complex logic when rendering the schedule, as we have to check the sort order of updates, and then that this is the first update etc.

Without this, we should be able to pull the schedule details out of the update partial and further simplify the structure.