### PR TITLE
More detailed timeliness

### DIFF
--- a/src/includes/notices/timeline-notice.liquid
+++ b/src/includes/notices/timeline-notice.liquid
@@ -15,7 +15,7 @@
                 <!-- Timeliness for all notices except drills. -->
                 {% if notice.state != 'drill' %}
                     <!-- Include the timeliness subheading. -->
-                    {% include 'notices/timeliness' placement: 'body' %}
+                    {% include 'notices/timeliness' %}
                 {% endif %}
 
                 <!-- Optional components for the notice. -->

--- a/src/includes/notices/timeliness.liquid
+++ b/src/includes/notices/timeliness.liquid
@@ -1,17 +1,15 @@
-<!-- Determine a friendly duration. -->
-{% assign duration = notice.duration | distance_of_time_in_words %}
+<div class="notice-timeliness">
+    {% if notice.began_at %}
+        <span class="notice-timeliness-began-at">
+            Began: <time datetime="{{ notice.began_at | date: '%FT%T%z' }}">{{ notice.began_at | date: '%-d %b %R' }}</time>
+        </span> - 
 
-<!-- Generate a moment.js time tag for the begins_at. -->
-{% capture begins_in %}
-    <!-- Use the time tag include. -->
-    {% include 'notices/time_tag' datetime: notice.begins_at %}
-{% endcapture %}
+        {% if notice.ended_at %}
+            <span class="notice-timeliness-ended-at">
+                Ended: <time datetime="{{ notice.ended_at | date: '%FT%T%z' }}">{{ notice.ended_at | date: '%-d %b %R' }}</time>
+            </span> - 
+        {% endif %}
 
-<!-- Generate a moment.js time tag for the begins_at. -->
-{% capture ends_in %}
-    <!-- Use the time tag include. -->
-    {% include 'notices/time_tag' datetime: notice.expected_ended_at %}
-{% endcapture %}
-
-<!-- Display a simple subheading. -->
-<small class="notice-type">{{ 'status-page.' | append: placement | append: '.timeliness.' | append: notice.type | append: '.' | append: notice.state | t: begins_in: begins_in, ends_in: ends_in, duration: duration }}</small>
+        <span class="notice-timeliness-duration">Duration: {{ notice.duration | distance_of_time_in_words }}</span>
+    {% endif %}
+</div>

--- a/src/includes/notices/timeliness.liquid
+++ b/src/includes/notices/timeliness.liquid
@@ -1,4 +1,4 @@
-<div class="notice-timeliness">
+<small class="notice-timeliness">
     {% if notice.began_at %}
         <span class="notice-timeliness-began-at">
             Began: <time datetime="{{ notice.began_at | date: '%FT%T%z' }}">{{ notice.began_at | date: '%-d %b %R' }}</time>
@@ -12,4 +12,4 @@
 
         <span class="notice-timeliness-duration">Duration: {{ notice.duration | distance_of_time_in_words }}</span>
     {% endif %}
-</div>
+</small>

--- a/src/includes/notices/timeliness.liquid
+++ b/src/includes/notices/timeliness.liquid
@@ -1,15 +1,15 @@
 <small class="notice-timeliness">
     {% if notice.began_at %}
         <span class="notice-timeliness-began-at">
-            Began: <time datetime="{{ notice.began_at | date: '%FT%T%z' }}">{{ notice.began_at | date: '%-d %b %R' }}</time>
+            {{ 'status-page.body.timeliness.began_at' | t }}: <time datetime="{{ notice.began_at | date: '%FT%T%z' }}">{{ notice.began_at | date: '%-d %b %R' }}</time>
         </span> - 
 
         {% if notice.ended_at %}
             <span class="notice-timeliness-ended-at">
-                Ended: <time datetime="{{ notice.ended_at | date: '%FT%T%z' }}">{{ notice.ended_at | date: '%-d %b %R' }}</time>
+                {{ 'status-page.body.timeliness.ended_at' | t }}: <time datetime="{{ notice.ended_at | date: '%FT%T%z' }}">{{ notice.ended_at | date: '%-d %b %R' }}</time>
             </span> - 
         {% endif %}
 
-        <span class="notice-timeliness-duration">Duration: {{ notice.duration | distance_of_time_in_words }}</span>
+        <span class="notice-timeliness-duration">{{ 'status-page.body.timeliness.duration' | t }}: {{ notice.duration | distance_of_time_in_words }}</span>
     {% endif %}
 </small>

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -49,6 +49,11 @@
                 "false_alarm": "Falsk Alarm",
                 "drill": "Bore"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },            
             "schedule": {
                 "for": "Planlagt til %{begins_at}",
                 "expected_duration": "Forventes at tage %{expected_duration}"

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -50,9 +50,9 @@
                 "drill": "Bore"
             },
             "timeliness": {
-                "began_at": "Began",
-                "ended_at": "Ended",
-                "duration": "Duration"
+                "began_at": "Begyndte",
+                "ended_at": "Endte",
+                "duration": "Varighed"
             },            
             "schedule": {
                 "for": "Planlagt til %{begins_at}",

--- a/src/locales/da.json
+++ b/src/locales/da.json
@@ -27,11 +27,6 @@
                 "recovering": "Udbedres",
                 "open": "Igangværende",
                 "underway": "Undervejs"
-            },
-            "timeliness": {
-                "planned": {
-                    "underway": "Vi forventer at være færdige på %{ends_in}"
-                }
             },              
             "disagree": {
                 "question": "Er du ikke enig?",
@@ -53,17 +48,6 @@
                 "resolved": "Løst",
                 "false_alarm": "Falsk Alarm",
                 "drill": "Bore"
-            },          
-            "timeliness": {
-                "planned": {
-                    "scheduled": "Forventes at begynde %{begins_in}",
-                    "complete": "Dette var et planlagt hændelse, tog det %{duration}."
-                },
-                "unplanned": {
-                    "closed": "Denne hændelse varede %{duration}.",
-                    "resolved": "Denne hændelse varede %{duration}.",
-                    "false_alarm": "Denne hændelse blev betragtet som en falsk alarm efter %{duration}"
-                }
             },
             "schedule": {
                 "for": "Planlagt til %{begins_at}",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -49,6 +49,11 @@
                 "false_alarm": "Falscher Alarm",
                 "drill": "Exerzieren"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Geplant für %{begins_at}",
                 "expected_duration": "Voraussichtliche Dauer: %{expected_duration}"

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -28,11 +28,6 @@
                 "open": "Fortlaufend",
                 "underway": "in Bearbeitung"
             },
-            "timeliness": {
-                "planned": {
-                    "underway": "Wir erwarten, dass wir %{ends_in} fertig sind"
-                }
-            },
             "disagree": {
                 "question": "Sind Sie damit nicht einverstanden?",
                 "answer": "Bitte geben Sie uns Bescheid"
@@ -53,17 +48,6 @@
                 "resolved": "Gelöst",
                 "false_alarm": "Falscher Alarm",
                 "drill": "Exerzieren"
-            },
-            "timeliness": {
-                "planned": {
-                    "scheduled": "Voraussichtlicher Beginn %{begins_in}",
-                    "complete": "Dies war ein geplantes Ereignis, es dauerte %{duration}."
-                },
-                "unplanned": {
-                    "closed": "Dieses Ereignis dauerte %{duration}.",
-                    "resolved": "Dieses Ereignis dauerte %{duration}.",
-                    "false_alarm": "Dieser Vorfall wurde als falscher Alarm nach %{duration} geschloßen."
-                }
             },
             "schedule": {
                 "for": "Geplant für %{begins_at}",

--- a/src/locales/de.json
+++ b/src/locales/de.json
@@ -50,9 +50,9 @@
                 "drill": "Exerzieren"
             },
             "timeliness": {
-                "began_at": "Began",
-                "ended_at": "Ended",
-                "duration": "Duration"
+                "began_at": "Begann",
+                "ended_at": "Beendet",
+                "duration": "Dauer"
             },
             "schedule": {
                 "for": "Geplant für %{begins_at}",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -27,11 +27,6 @@
                 "recovering": "Ανάκτηση",
                 "open": "Σε εξέλιξη",
                 "underway": "σε εξέλιξη"
-            },
-            "timeliness": {
-                "planned": {
-                    "underway": "Περιμένουμε να τελειώσει %{ends_in}"
-                }
             },          
             "disagree": {
                 "question": "Δεν συμφωνώ με αυτό;",
@@ -53,17 +48,6 @@
                 "resolved": "επιλυθεί",
                 "false_alarm": "Λάθος συναγερμός",
                 "drill": "άσκηση"
-            },          
-            "timeliness": {
-                "planned": {
-                    "scheduled": "Αναμένεται να ξεκινήσει %{begins_in}",
-                    "complete": "Αυτή ήταν μια προγραμματισμένη περιστατικό, πήρε %{duration}."
-                },
-                "unplanned": {
-                    "closed": "Το περιστατικό διήρκεσε %{duration}.",
-                    "resolved": "Το περιστατικό διήρκεσε %{duration}.",
-                    "false_alarm": "Αυτό το περιστατικό θεωρήθηκε ψευδές συναγερμό μετά %{duration}"
-                }
             },
             "schedule": {
                 "for": "Προγραμματισμενο για %{begins_at}",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -50,9 +50,9 @@
                 "drill": "άσκηση"
             },
             "timeliness": {
-                "began_at": "Began",
-                "ended_at": "Ended",
-                "duration": "Duration"
+                "began_at": "Άρχισε",
+                "ended_at": "Τέλος",
+                "duration": "Διάρκεια"
             },
             "schedule": {
                 "for": "Προγραμματισμενο για %{begins_at}",

--- a/src/locales/el.json
+++ b/src/locales/el.json
@@ -49,6 +49,11 @@
                 "false_alarm": "Λάθος συναγερμός",
                 "drill": "άσκηση"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Προγραμματισμενο για %{begins_at}",
                 "expected_duration": "Αναμένεται να λάβει %{expected_duration}"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -54,6 +54,11 @@
                 "ended_at": "Ended",
                 "duration": "Duration"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Scheduled for %{begins_at}",
                 "expected_duration": "Expected to take %{expected_duration}"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -49,6 +49,11 @@
                 "false_alarm": "False Alarm",
                 "drill": "Drill"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Scheduled for %{begins_at}",
                 "expected_duration": "Expected to take %{expected_duration}"

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -27,11 +27,6 @@
                 "recovering": "Recovering",
                 "open": "Ongoing",
                 "underway": "Underway"
-            },
-            "timeliness": {
-                "planned": {
-                    "underway": "We expect to be finished %{ends_in}"
-                }
             },          
             "disagree": {
                 "question": "Don't agree with this?",
@@ -53,17 +48,6 @@
                 "resolved": "Resolved",
                 "false_alarm": "False Alarm",
                 "drill": "Drill"
-            },          
-            "timeliness": {
-                "planned": {
-                    "scheduled": "Expected to begin %{begins_in}",
-                    "complete": "This was a planned incident, it took %{duration}."
-                },
-                "unplanned": {
-                    "closed": "This incident lasted %{duration}.",
-                    "resolved": "This incident lasted %{duration}.",
-                    "false_alarm": "This incident was deemed a false alarm after %{duration}"
-                }
             },
             "schedule": {
                 "for": "Scheduled for %{begins_at}",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -49,6 +49,11 @@
                 "false_alarm": "Falsa Alarma",
                 "drill": "Ejercitarse"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Programado para %{begins_at}",
                 "expected_duration": "Se espera que tome %{expected_duration}"

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -27,12 +27,7 @@
                 "recovering": "Recuperante",
                 "open": "En marcha",
                 "underway": "En curso"
-            },
-            "timeliness": {
-                "planned": {
-                    "underway": "Esperamos que terminemos %{ends_in}"
-                }
-            },          
+            },       
             "disagree": {
                 "question": "¿No estás de acuerdo con esto?",
                 "answer": "Por favor déjanos saber"
@@ -53,17 +48,6 @@
                 "resolved": "Resuelto",
                 "false_alarm": "Falsa Alarma",
                 "drill": "Ejercitarse"
-            },          
-            "timeliness": {
-                "planned": {
-                    "scheduled": "Se espera que comience %{begins_in}",
-                    "complete": "Este fue un incidente planeado, %{duration}."
-                },
-                "unplanned": {
-                    "closed": "Este incidente duró %{duration}.",
-                    "resolved": "Este incidente duró %{duration}.",
-                    "false_alarm": "Este incidente fue considerado una falsa alarma %{duration}"
-                }
             },
             "schedule": {
                 "for": "Programado para %{begins_at}",

--- a/src/locales/es.json
+++ b/src/locales/es.json
@@ -50,9 +50,9 @@
                 "drill": "Ejercitarse"
             },
             "timeliness": {
-                "began_at": "Began",
-                "ended_at": "Ended",
-                "duration": "Duration"
+                "began_at": "Empezó",
+                "ended_at": "Terminó",
+                "duration": "Duración"
             },
             "schedule": {
                 "for": "Programado para %{begins_at}",

--- a/src/locales/et.json
+++ b/src/locales/et.json
@@ -27,11 +27,6 @@
                 "recovering": "Taastamisel",
                 "open": "Jätkuv",
                 "underway": "Käimasolev"
-            },
-            "timeliness": {
-                "planned": {
-                    "underway": "Loodame valmis saada %{ends_in}"
-                }
             },          
             "disagree": {
                 "question": "Kas sa ei nõustu sellega?",
@@ -53,17 +48,6 @@
                 "resolved": "Lahendatud",
                 "false_alarm": "Vale alarm",
                 "drill": "Harjutama"
-            },          
-            "timeliness": {
-                "planned": {
-                    "scheduled": " %{begins_in}",
-                    "complete": "See oli planeeritud intsident, ja see võttis %{duration}."
-                },
-                "unplanned": {
-                    "closed": "See intsident kestis %{duration}.",
-                    "resolved": "See intsident kestis %{duration}.",
-                    "false_alarm": "See intsident oli vale alarm %{duration}"
-                }
             },
             "schedule": {
                 "for": "Planeeritud: %{begins_at}",

--- a/src/locales/et.json
+++ b/src/locales/et.json
@@ -50,9 +50,9 @@
                 "drill": "Harjutama"
             },
             "timeliness": {
-                "began_at": "Began",
-                "ended_at": "Ended",
-                "duration": "Duration"
+                "began_at": "Algas",
+                "ended_at": "Lõppenud",
+                "duration": "Kestus"
             },
             "schedule": {
                 "for": "Planeeritud: %{begins_at}",

--- a/src/locales/et.json
+++ b/src/locales/et.json
@@ -49,6 +49,11 @@
                 "false_alarm": "Vale alarm",
                 "drill": "Harjutama"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Planeeritud: %{begins_at}",
                 "expected_duration": "Arvatud kestus %{expected_duration}"

--- a/src/locales/fi..json
+++ b/src/locales/fi..json
@@ -28,11 +28,6 @@
                 "open": "Avoin",
                 "underway": "Käynnissä"
             },
-            "timeliness": {
-                "planned": {
-                    "underway": "Odotettu valmistuminen %{ends_in}"
-                }
-            },
             "disagree": {
                 "question": "Et ole samaa mieltä?",
                 "answer": "Ota meihin yhteyttä "
@@ -53,17 +48,6 @@
                 "resolved": "Ratkaistu",
                 "false_alarm": "Väärä hälytys",
                 "drill": "Harjoittaa"
-            },
-            "timeliness": {
-                "planned": {
-                    "scheduled": "Odotettu aloitus %{begins_in}",
-                    "complete": "Tämä oli suunniteltu tapahtuma, kesto %{duration}."
-                },
-                "unplanned": {
-                    "closed": "Tapahtuman kesto oli %{duration}.",
-                    "resolved": "Tapahtuman kesto oli %{duration}.",
-                    "false_alarm": "Tämä tapahtuma katsottiin olevan väärä hälytys %{duration} jälkeen"
-                }
             },
             "schedule": {
                 "for": "Ajoitettu %{begins_at}",

--- a/src/locales/fi..json
+++ b/src/locales/fi..json
@@ -49,6 +49,11 @@
                 "false_alarm": "Väärä hälytys",
                 "drill": "Harjoittaa"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Ajoitettu %{begins_at}",
                 "expected_duration": "Odotettu kesto %{expected_duration}"

--- a/src/locales/fi..json
+++ b/src/locales/fi..json
@@ -50,9 +50,9 @@
                 "drill": "Harjoittaa"
             },
             "timeliness": {
-                "began_at": "Began",
-                "ended_at": "Ended",
-                "duration": "Duration"
+                "began_at": "Alkoi",
+                "ended_at": "Päättynyt",
+                "duration": "Kesto"
             },
             "schedule": {
                 "for": "Ajoitettu %{begins_at}",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -49,6 +49,11 @@
                 "false_alarm": "Fausse Alarme",
                 "drill": "l' exercice"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Planifié pour %{begins_at}",
                 "expected_duration": "Prévu pour prendre %{expected_duration}"

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -50,9 +50,9 @@
                 "drill": "l' exercice"
             },
             "timeliness": {
-                "began_at": "Began",
-                "ended_at": "Ended",
-                "duration": "Duration"
+                "began_at": "A commencé",
+                "ended_at": "Terminé",
+                "duration": "Durée"
             },
             "schedule": {
                 "for": "Planifié pour %{begins_at}",

--- a/src/locales/fr.json
+++ b/src/locales/fr.json
@@ -27,11 +27,6 @@
                 "recovering": "Récupération",
                 "open": "En cours",
                 "underway": "En cours"
-            },
-            "timeliness": {
-                "planned": {
-                    "underway": "Nous prévoyons avoir terminé %{ends_in}"
-                }
             },      
             "disagree": {
                 "question": "Vous rencontrez un problème ?",
@@ -53,17 +48,6 @@
                 "resolved": "Résolu",
                 "false_alarm": "Fausse Alarme",
                 "drill": "l' exercice"
-            },          
-            "timeliness": {
-                "planned": {
-                    "scheduled": "Prévu pour commencer %{begins_in}",
-                    "complete": "Il s'agissait d'un incident planifié %{duration}."
-                },
-                "unplanned": {
-                    "closed": "Cet incident a duré %{duration}.",
-                    "resolved": "Cet incident a duré %{duration}.",
-                    "false_alarm": "Cet incident a été considéré comme une fausse alarme après %{duration}"
-                }
             },
             "schedule": {
                 "for": "Planifié pour %{begins_at}",

--- a/src/locales/nb.json
+++ b/src/locales/nb.json
@@ -50,9 +50,9 @@
                 "drill": "øvelse"
             },
             "timeliness": {
-                "began_at": "Began",
-                "ended_at": "Ended",
-                "duration": "Duration"
+                "began_at": "Begynte",
+                "ended_at": "Endte",
+                "duration": "Varighet"
             },
             "schedule": {
                 "for": "Planlagt %{begins_at}",

--- a/src/locales/nb.json
+++ b/src/locales/nb.json
@@ -49,6 +49,11 @@
                 "false_alarm": "Falsk Alarm",
                 "drill": "øvelse"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Planlagt %{begins_at}",
                 "expected_duration": "Forventet å ta %{expected_duration}"

--- a/src/locales/nb.json
+++ b/src/locales/nb.json
@@ -27,11 +27,6 @@
                 "recovering": "Gjennoppretter",
                 "open": "Pågående",
                 "underway": "Underveis"
-            },
-            "timeliness": {
-                "planned": {
-                    "underway": "Vi planlegger å være ferdig %{ends_in}"
-                }
             },          
             "disagree": {
                 "question": "Er du uenig i dette?",
@@ -53,17 +48,6 @@
                 "resolved": "Løst",
                 "false_alarm": "Falsk Alarm",
                 "drill": "øvelse"
-            },          
-            "timeliness": {
-                "planned": {
-                    "scheduled": "Forventet å begynne %{begins_in}",
-                    "complete": "Dette var en planlagt hendelse, det tok %{duration}."
-                },
-                "unplanned": {
-                    "closed": "Denne hendelsen varte %{duration}.",
-                    "resolved": "Denne hendelsen varte %{duration}.",
-                    "false_alarm": "Denne hendelsen ble ansett som en falsk alarm etter %{duration}"
-                }
             },
             "schedule": {
                 "for": "Planlagt %{begins_at}",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -49,6 +49,11 @@
                 "false_alarm": "Vals alarm",
                 "drill": "Uitoefening"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Gepland voor %{begins_at}",
                 "expected_duration": "Verwachte duur %{expected_duration}"

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -50,9 +50,9 @@
                 "drill": "Uitoefening"
             },
             "timeliness": {
-                "began_at": "Began",
+                "began_at": "Begon",
                 "ended_at": "Ended",
-                "duration": "Duration"
+                "duration": "Looptijd"
             },
             "schedule": {
                 "for": "Gepland voor %{begins_at}",

--- a/src/locales/nl.json
+++ b/src/locales/nl.json
@@ -27,11 +27,6 @@
                 "recovering": "Herstellende",
                 "open": "Open",
                 "underway": "Bezig"
-            },
-            "timeliness": {
-                "planned": {
-                    "underway": "We verwachten klaar te zijn over %{ends_in}"
-                }
             },          
             "disagree": {
                 "question": "Werkt er iets niet?",
@@ -53,17 +48,6 @@
                 "resolved": "Opgelost",
                 "false_alarm": "Vals alarm",
                 "drill": "Uitoefening"
-            },          
-            "timeliness": {
-                "planned": {
-                    "scheduled": "We verwachten te beginnen over %{begins_in}",
-                    "complete": "Dit geplande onderhoud duurde %{duration}."
-                },
-                "unplanned": {
-                    "closed": "Dit incident duurde %{duration}.",
-                    "resolved": "Dit incident duurde %{duration}.",
-                    "false_alarm": "Dit incident werd gemarkeerd als vals alarm na %{duration}"
-                }
             },
             "schedule": {
                 "for": "Gepland voor %{begins_at}",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -49,6 +49,11 @@
                 "false_alarm": "Fałszywy alarm",
                 "drill": "Musztrować"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Start %{begins_at}",
                 "expected_duration": "Szacowany czas pracy %{expected_duration}"

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -50,9 +50,9 @@
                 "drill": "Musztrować"
             },
             "timeliness": {
-                "began_at": "Began",
-                "ended_at": "Ended",
-                "duration": "Duration"
+                "began_at": "Zaczynać",
+                "ended_at": "Zakończony",
+                "duration": "Trwanie"
             },
             "schedule": {
                 "for": "Start %{begins_at}",

--- a/src/locales/pl.json
+++ b/src/locales/pl.json
@@ -28,11 +28,6 @@
                 "open": "W trakcie",
                 "underway": "W toku"
             },
-            "timeliness": {
-                "planned": {
-                    "underway": "Szacujemy, że zakończymy prace %{ends_in}"
-                }
-            },
             "disagree": {
                 "question": "Nie zgadzasz się?",
                 "answer": "Daj nam znać"
@@ -53,17 +48,6 @@
                 "resolved": "Rozwiązane",
                 "false_alarm": "Fałszywy alarm",
                 "drill": "Musztrować"
-            },
-            "timeliness": {
-                "planned": {
-                    "scheduled": "Start za %{begins_in} ",
-                    "complete": "To była zaplanowana operacja, która trwała %{duration}."
-                },
-                "unplanned": {
-                    "closed": "Zdarzenie trwało %{duration}.",
-                    "resolved": "Zdarzenie trwało %{duration}.",
-                    "false_alarm": "Zdarzenie zostało uznane za fałszywy alarm po %{duration}"
-                }
             },
             "schedule": {
                 "for": "Start %{begins_at}",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -50,9 +50,9 @@
                 "drill": "A prática"
             },
             "timeliness": {
-                "began_at": "Began",
-                "ended_at": "Ended",
-                "duration": "Duration"
+                "began_at": "Começasse",
+                "ended_at": "Terminado",
+                "duration": "Duração"
             },
             "schedule": {
                 "for": "Programado para %{begins_at}",

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -49,6 +49,11 @@
                 "false_alarm": "Alarme Falso",
                 "drill": "A prática"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Programado para %{begins_at}",
                 "expected_duration": "Esperado durar %{expected_duration}"

--- a/src/locales/pt-BR.json
+++ b/src/locales/pt-BR.json
@@ -28,11 +28,6 @@
                 "open": "Em andamento",
                 "underway": "Em andamento"
             },
-            "timeliness": {
-                "planned": {
-                    "underway": "Esperamos concluir em %{ends_in}"
-                }
-            },
             "disagree": {
                 "question": "Não concorda?",
                 "answer": "Por favor, informe-nos o motivo."
@@ -53,17 +48,6 @@
                 "resolved": "Resolvido",
                 "false_alarm": "Alarme Falso",
                 "drill": "A prática"
-            },
-            "timeliness": {
-                "planned": {
-                    "scheduled": "Esperado para começar em %{begins_in}",
-                    "complete": "Este incidente planejado teve duração de %{duration}."
-                },
-                "unplanned": {
-                    "closed": "Este incidente teve duração de %{duration}.",
-                    "resolved": "Este incidente teve duração de %{duration}.",
-                    "false_alarm": "Este incidente foi considerado um alarme falso após %{duration}"
-                }
             },
             "schedule": {
                 "for": "Programado para %{begins_at}",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -50,9 +50,9 @@
                 "drill": "Yпражнение"
             },
             "timeliness": {
-                "began_at": "Began",
-                "ended_at": "Ended",
-                "duration": "Duration"
+                "began_at": "Начал",
+                "ended_at": "Закончилось",
+                "duration": "длительность"
             },
             "schedule": {
                 "for": "Запланировано на %{begins_at} ",

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -49,6 +49,11 @@
                 "false_alarm": "Ложная тревога",
                 "drill": "Yпражнение"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Запланировано на %{begins_at} ",
                 "expected_duration": "Должно занять %{expected_duration}"

--- a/src/locales/ru.json
+++ b/src/locales/ru.json
@@ -27,11 +27,6 @@
                 "recovering": "Восстановление",
                 "open": "Открыто",
                 "underway": "В процессе"
-            },
-            "timeliness": {
-                "planned": {
-                    "underway": "Мы ожидаем закончить %{ends_in}"
-                }
             },          
             "disagree": {
                 "question": "Не согласны с этим?",
@@ -53,17 +48,6 @@
                 "resolved": "Найдено решение",
                 "false_alarm": "Ложная тревога",
                 "drill": "Yпражнение"
-            },          
-            "timeliness": {
-                "planned": {
-                    "scheduled": "Должно начаться %{begins_in}",
-                    "complete": "Это был запланированный инцидент, он занял %{duration}."
-                },
-                "unplanned": {
-                    "closed": "Этот инцидент длился %{duration}.",
-                    "resolved": "Этот инцидент длился %{duration}.",
-                    "false_alarm": "Этот инцидент был признан ложной тревогой через %{duration}"
-                }
             },
             "schedule": {
                 "for": "Запланировано на %{begins_at} ",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -27,11 +27,6 @@
                 "recovering": "Åtgärdas",
                 "open": "Pågående",
                 "underway": "På gång"
-            },
-            "timeliness": {
-                "planned": {
-                    "underway": "Vi räknar med att vara klar %{ends_in}"
-                }
             },              
             "disagree": {
                 "question": "Är du inte enig?",
@@ -53,17 +48,6 @@
                 "resolved": "Åtgärdat",
                 "false_alarm": "Falsklarm",
                 "drill": "Träna"
-            },          
-            "timeliness": {
-                "planned": {
-                    "scheduled": "Väntas börja på %{begins_in}",
-                    "complete": "Detta var en planerad händelse, tog det %{duration}."
-                },
-                "unplanned": {
-                    "closed": "Denna incident varade %{duration}.",
-                    "resolved": "Denna incident varade %{duration}.",
-                    "false_alarm": "Denna händelse ansågs vara ett falskt larm efter %{duration}"
-                }
             },
             "schedule": {
                 "for": "Schemalagt för %{begins_at}",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -50,9 +50,9 @@
                 "drill": "Träna"
             },
             "timeliness": {
-                "began_at": "Began",
-                "ended_at": "Ended",
-                "duration": "Duration"
+                "began_at": "Började",
+                "ended_at": "Slutade",
+                "duration": "Varaktighet"
             },
             "schedule": {
                 "for": "Schemalagt för %{begins_at}",

--- a/src/locales/sv.json
+++ b/src/locales/sv.json
@@ -49,6 +49,11 @@
                 "false_alarm": "Falsklarm",
                 "drill": "Träna"
             },
+            "timeliness": {
+                "began_at": "Began",
+                "ended_at": "Ended",
+                "duration": "Duration"
+            },
             "schedule": {
                 "for": "Schemalagt för %{begins_at}",
                 "expected_duration": "Förväntas ta %{expected_duration}"

--- a/src/status-page.liquid
+++ b/src/status-page.liquid
@@ -68,7 +68,7 @@
                                                 <!-- Display appropriate schedule information if we have it. -->
                                                 {% if notice.type == 'planned' %}
                                                     <!-- Display the schedule/runtime. -->
-                                                    {% include 'notices/timeliness' placement: 'header' %}
+                                                    {% include 'notices/timeliness' %}
                                                 {% endif %}
                                             </div>
 

--- a/src/status-page.liquid
+++ b/src/status-page.liquid
@@ -65,11 +65,8 @@
                                                 <!-- The basic subject line. -->
                                                 <h3 class="notice-subject h4">{{ notice.subject }}</h3>
 
-                                                <!-- Display appropriate schedule information if we have it. -->
-                                                {% if notice.type == 'planned' %}
-                                                    <!-- Display the schedule/runtime. -->
-                                                    {% include 'notices/timeliness' %}
-                                                {% endif %}
+                                                <!-- Display the schedule/runtime. -->
+                                                {% include 'notices/timeliness' %}
                                             </div>
 
                                             <dl>

--- a/src/stylesheets/partials/timelines.less
+++ b/src/stylesheets/partials/timelines.less
@@ -115,7 +115,7 @@ dl.timeline {
         }
 
         /* Subheading styles. */
-        .notice-type { 
+        .notice-timeliness { 
             display: block;
             opacity: 0.6;
             font-size: 85%;

--- a/src/stylesheets/partials/timelines.less
+++ b/src/stylesheets/partials/timelines.less
@@ -117,7 +117,7 @@ dl.timeline {
         /* Subheading styles. */
         .notice-timeliness { 
             display: block;
-            opacity: 0.6;
+            opacity: 0.8;
             font-size: 85%;
             line-height: 1.41;
             margin-bottom: (@line-height-computed / 2);


### PR DESCRIPTION
Contribution to #119 and #118 - The "timeliness" subheading now includes the explicit began, ended and duration times for notices.

This explicit information replaces the slightly wooley context-based sentences we used before.