### PR TITLE
Duration conditional + timestamps

### DIFF
--- a/src/includes/notices/schedule-overview.liquid
+++ b/src/includes/notices/schedule-overview.liquid
@@ -4,12 +4,12 @@
         <!-- Format the begins-date datetime as something more friendly. -->
         {% assign begins_at = notice.begins_at | date: '%a, %-d %b %Y %H:%M %Z' %}
         <!-- Display the begins-at datetime for the notice. -->
-        <i class="fa fa-fw fa-calendar"></i> {{ 'status-page.body.schedule.for' | t: begins_at: begins_at }}
+        <i class="fa fa-fw fa-calendar"></i> <time datetime="{{ notice.begins_at | date: '%FT%T%z' }}">{{ 'status-page.body.schedule.for' | t: begins_at: begins_at }}</time>
     </li>
     <li class="schedule-duration">
         <!-- Create a friendly version of the duration. -->
         {% assign expected_duration = notice.expected_duration | distance_of_time_in_words %}
         <!-- Output the duration. -->
-        <i class="fa fa-fw fa-clock-o"></i> {{ 'status-page.body.schedule.expected_duration' | t: expected_duration: expected_duration }}
+        <i class="fa fa-fw fa-clock-o"></i> <time datetime="PT{{ notice.expected_duration }}S">{{ 'status-page.body.schedule.expected_duration' | t: expected_duration: expected_duration }}</time>
     </li>
 </ul>

--- a/src/includes/notices/timeline-notice.liquid
+++ b/src/includes/notices/timeline-notice.liquid
@@ -55,7 +55,9 @@
                 {% endif %}
 
                 <!-- Output the time for the given update. -->
-                <dt id="update-{{ update.id }}">{{ update.created_at | date: '%X %Z' }}</dt>
+                <dt id="update-{{ update.id }}">
+                    <time datetime="{{ update.created_at | date: '%X' }}">{{ update.created_at | date: '%X %Z' }}</time>
+                </dt>
                     <!-- Output the text content of the update. -->
                     <dd>{{ update.content | simple_format }}</dd>
 

--- a/src/includes/notices/timeline-notice.liquid
+++ b/src/includes/notices/timeline-notice.liquid
@@ -37,7 +37,9 @@
                 <!-- See if this is the first iteration of the loop. -->
                 {% if forloop.first %}
                     <!-- First iteration, as a date stamp to it. -->
-                    <dt>{{ grouped_date }}</dt>
+                    <dt>
+                        <time datetime="{{ update.created_at | date: '%F' }}">{{ grouped_date }}</time>
+                    </dt>
                     <dd>
                         <dl>
                 {% else %}
@@ -48,7 +50,9 @@
                         </dd>
 
                         <!-- End start a new nested collection. -->
-                        <dt>{{ grouped_date }}</dt>
+                        <dt>
+                            <time datetime="{{ update.created_at | date: '%F' }}">{{ grouped_date }}</time>
+                        </dt>    
                         <dd>
                             <dl>
                     {% endif %}

--- a/src/includes/notices/timeline-notice.liquid
+++ b/src/includes/notices/timeline-notice.liquid
@@ -60,7 +60,7 @@
 
                 <!-- Output the time for the given update. -->
                 <dt id="update-{{ update.id }}">
-                    <time datetime="{{ update.created_at | date: '%X' }}">{{ update.created_at | date: '%X %Z' }}</time>
+                    <time datetime="{{ update.created_at | date: '%T%z' }}">{{ update.created_at | date: '%X %Z' }}</time>
                 </dt>
                     <!-- Output the text content of the update. -->
                     <dd>{{ update.content | simple_format }}</dd>

--- a/src/includes/notices/timeliness.liquid
+++ b/src/includes/notices/timeliness.liquid
@@ -2,12 +2,12 @@
     {% if notice.began_at %}
         <span class="notice-timeliness-began-at">
             {{ 'status-page.body.timeliness.began_at' | t }}: <time datetime="{{ notice.began_at | date: '%FT%T%z' }}">{{ notice.began_at | date: '%-d %b %R' }}</time>
-        </span> - 
+        </span>
 
         {% if notice.ended_at %}
             <span class="notice-timeliness-ended-at">
                 {{ 'status-page.body.timeliness.ended_at' | t }}: <time datetime="{{ notice.ended_at | date: '%FT%T%z' }}">{{ notice.ended_at | date: '%-d %b %R' }}</time>
-            </span> - 
+            </span>
         {% endif %}
     {% endif %}
 

--- a/src/includes/notices/timeliness.liquid
+++ b/src/includes/notices/timeliness.liquid
@@ -12,6 +12,8 @@
     {% endif %}
 
     {% if notice.duration %}
-        <span class="notice-timeliness-duration">{{ 'status-page.body.timeliness.duration' | t }}: {{ notice.duration | distance_of_time_in_words }}</span>
+        <span class="notice-timeliness-duration">{{ 'status-page.body.timeliness.duration' | t }}: 
+            <time datetime="PT{{ notice.duration }}S">{{ notice.duration | distance_of_time_in_words }}</time>
+        </span>
     {% endif %}
 </small>

--- a/src/includes/notices/timeliness.liquid
+++ b/src/includes/notices/timeliness.liquid
@@ -9,7 +9,9 @@
                 {{ 'status-page.body.timeliness.ended_at' | t }}: <time datetime="{{ notice.ended_at | date: '%FT%T%z' }}">{{ notice.ended_at | date: '%-d %b %R' }}</time>
             </span> - 
         {% endif %}
+    {% endif %}
 
+    {% if notice.duration %}
         <span class="notice-timeliness-duration">{{ 'status-page.body.timeliness.duration' | t }}: {{ notice.duration | distance_of_time_in_words }}</span>
     {% endif %}
 </small>

--- a/src/maintenance-page.liquid
+++ b/src/maintenance-page.liquid
@@ -53,7 +53,7 @@
                             <!-- The SP does have noticed, display an ongoing statement and link. -->
                             <h2 class="h4 notice-subject">{{ notice.subject }}</h2>
                                 <p class="notice-synopsis">{{ notice.synopsis | simple_format }}</p>
-                                <p class="notice-schedule"><small><strong>{{ 'maintenance-page.body.states.with-maintenance.began_at' | t }}:</strong> {{ notice.began_at | date: '%A, %-d %b %Y %H:%M %Z' }} <br /> <strong>{{ 'maintenance-page.body.states.with-maintenance.duration' | t }}:</strong> <time class="duration" datetime="{{ notice.expected_duration }}s">{{ notice.expected_duration | distance_of_time_in_words }}</time></small></p>
+                                <p class="notice-schedule"><small><strong>{{ 'maintenance-page.body.states.with-maintenance.began_at' | t }}:</strong> {{ notice.began_at | date: '%A, %-d %b %Y %H:%M %Z' }} <br /> <strong>{{ 'maintenance-page.body.states.with-maintenance.duration' | t }}:</strong> <time class="duration" datetime="PT{{ notice.expected_duration }}S">{{ notice.expected_duration | distance_of_time_in_words }}</time></small></p>
                         </div>
 
                         <div class="spacer spacer-md"></div>

--- a/src/stylesheets/partials/timelines.less
+++ b/src/stylesheets/partials/timelines.less
@@ -121,6 +121,13 @@ dl.timeline {
             font-size: 85%;
             line-height: 1.41;
             margin-bottom: (@line-height-computed / 2);
+
+            span:not(:last-child):after {
+                display: inline-block;
+                content: '-';
+                margin-left: 4px;
+                margin-right: 4px;
+            }
         }
 
         .list-affected-components { font-size: 18px; }


### PR DESCRIPTION
Contribution to #121 - duration is now only displayed when available (only for historic notices) - and all the date, times and durations now use the semantic time tag with the correct ISO datetime format.