### PR TITLE
Removed use of simple_format

### DIFF
--- a/src/includes/notices/timeline-notice.liquid
+++ b/src/includes/notices/timeline-notice.liquid
@@ -63,7 +63,7 @@
                     <time datetime="{{ update.created_at | date: '%T%z' }}">{{ update.created_at | date: '%X %Z' }}</time>
                 </dt>
                     <!-- Output the text content of the update. -->
-                    <dd>{{ update.content | simple_format }}</dd>
+                    <dd>{{ update.content }}</dd>
 
                 <!-- Check if this is the last instance of the loop. -->
                 {% if forloop.last %}

--- a/src/maintenance-page.liquid
+++ b/src/maintenance-page.liquid
@@ -52,7 +52,7 @@
                         <div class="notice" id="{{ notice.id }}">
                             <!-- The SP does have noticed, display an ongoing statement and link. -->
                             <h2 class="h4 notice-subject">{{ notice.subject }}</h2>
-                                <p class="notice-synopsis">{{ notice.synopsis | simple_format }}</p>
+                                <p class="notice-synopsis">{{ notice.synopsis }}</p>
                                 <p class="notice-schedule"><small><strong>{{ 'maintenance-page.body.states.with-maintenance.began_at' | t }}:</strong> {{ notice.began_at | date: '%A, %-d %b %Y %H:%M %Z' }} <br /> <strong>{{ 'maintenance-page.body.states.with-maintenance.duration' | t }}:</strong> <time class="duration" datetime="PT{{ notice.expected_duration }}S">{{ notice.expected_duration | distance_of_time_in_words }}</time></small></p>
                         </div>
 

--- a/src/status-page.liquid
+++ b/src/status-page.liquid
@@ -89,7 +89,7 @@
                                                         {% include 'notices/time_tag' datetime: update.created_at %}
                                                     </dt>
                                                         <!-- Output the text content of the update. -->
-                                                        <dd>{{ update.content | simple_format }}</dd>
+                                                        <dd>{{ update.content }}</dd>
                                                 {% endfor %}
                                             </dl>
 


### PR DESCRIPTION
This is because markdown support returns HTML from update.content which doesn't need line breaks swapping for paragraphs.